### PR TITLE
add check_sentry_messages.py to script in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
         "Topic :: Software Development :: Libraries :: Application Frameworks",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
+    scripts=['check_sentry_messages.py'],
 )


### PR DESCRIPTION
added to check_sentry_messages.py as a script in setup.py so that when doing a pip install in a virtualenv it gets installed into the bin directory
